### PR TITLE
Fix highlighting xml/html code by escaping html characters

### DIFF
--- a/lib/highlightjs_highlighting.rb
+++ b/lib/highlightjs_highlighting.rb
@@ -2,11 +2,11 @@ module HighlightJsSyntaxHighlighting
   class << self
     def highlight_by_filename(text, filename)
       Rails.logger.info "redmine_highlightjs: syntax by filename #{filename}"  
-      return text
+      return ERB::Util.h(text)
     end
     def highlight_by_language(text, language)
       Rails.logger.info "redmine_highlightjs: syntax #{language}"
-      return text
+      return ERB::Util.h(text)
     end
   end
 end


### PR DESCRIPTION
Here is bug, no escape html characters:
![redmine_highlightjs bug](https://cloud.githubusercontent.com/assets/8553102/23940320/0bdbf06c-0997-11e7-98a7-678674181563.png)
After fix:
![redmine_highlightjs fix](https://cloud.githubusercontent.com/assets/8553102/23940323/0f0bb038-0997-11e7-923d-1687f7a1281b.png)




